### PR TITLE
fix: large css bundle

### DIFF
--- a/packages/ui-components/index.html
+++ b/packages/ui-components/index.html
@@ -1,16 +1,28 @@
 <!doctype html>
 <html lang="en">
-  
+
 <head>
   <meta charset="UTF-8" />
   <link rel="icon" type="image/svg+xml" href="/vite.svg" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Vite + Lit + TS</title>
   <script type="module" src="./src/main.ts"></script>
+  <style>
+    body {
+      @apply bg-neutral-800
+    }
+
+    #root {
+      @apply max-w-screen-lg m-auto
+    }
+  </style>
 </head>
-<body class="bg-neutral-800" style="width:1000px;margin:0 auto;">
-  <top-bar><profile-button slot="user"></profile-button></top-bar>
-  <getting-started-step-overview></getting-started-step-overview>
+
+<body>
+  <div id="root">
+    <top-bar><profile-button slot="user"></profile-button></top-bar>
+    <getting-started-step-overview></getting-started-step-overview>
+  </div>
 </body>
 
 </html>

--- a/packages/ui-components/src/index.css
+++ b/packages/ui-components/src/index.css
@@ -1,4 +1,0 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
-@tailwind screens;

--- a/packages/ui-components/src/main.ts
+++ b/packages/ui-components/src/main.ts
@@ -1,5 +1,3 @@
-import './index.css';
-
 export { ProfileButton } from './components/profile-button';
 import './exports/profile-button';
 
@@ -20,4 +18,3 @@ import './exports/common/result-item';
 
 export { TopBar } from './components/top-bar';
 import './exports/top-bar';
-


### PR DESCRIPTION
Fixed an issue where the generated tailwind stylesheet contained unnecessary classes.

before:
![image](https://github.com/stryker-mutator/stryker-dashboard/assets/1756725/624386f3-5a62-4350-8c38-d188af2d9c11)

after:
![image](https://github.com/stryker-mutator/stryker-dashboard/assets/1756725/93b3590f-79d5-4c9e-8654-6fec62bca26c)
