### PR TITLE
feat: enable sourcemaps for improved debugging

### DIFF
--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.1",
   "type": "module",
   "files": [
-    "dist/build",
-    "dist/types"
+    "dist",
+    "src"
   ],
   "module": "./dist/main.mjs",
   "main": "./dist/main.cjs",

--- a/packages/ui-components/tsconfig.json
+++ b/packages/ui-components/tsconfig.json
@@ -16,14 +16,13 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
+    "declaration": true,
+    "declarationMap": true,
     /* Linting */
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true,
-
-    "declaration": true,
-    "declarationMap": true
+    "noFallthroughCasesInSwitch": true
   },
   "include": [
     "src"

--- a/packages/ui-components/tsconfig.json
+++ b/packages/ui-components/tsconfig.json
@@ -20,7 +20,10 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+
+    "declaration": true,
+    "declarationMap": true
   },
   "include": [
     "src"

--- a/packages/ui-components/vite.config.ts
+++ b/packages/ui-components/vite.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
   ],
   build: {
     target: 'ESNext',
+    sourcemap: true,
     minify: false,
     outDir: BUILD_DIR,
     emptyOutDir: true,


### PR DESCRIPTION
The resulting dist folder now includes both source maps and declaration maps.

![image](https://github.com/JortWillemsen/stryker-dashboard-redesign/assets/1756725/5dd8f669-ca41-40b2-ad00-50a7bb0a6998)

---

The src folder is included in npm publish. This way the declaration maps can link to the corresponding typescript files.

![image](https://github.com/JortWillemsen/stryker-dashboard-redesign/assets/1756725/02eb5b70-c9f6-4796-a558-7810f12d5405)
![image](https://github.com/JortWillemsen/stryker-dashboard-redesign/assets/1756725/7f0d563d-2637-4711-9c8a-dd24bdd0029b)
